### PR TITLE
fix #9 and config-ui accessory reference

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1,8 +1,8 @@
 {
-	"pluginAlias": "Awair",
+	"pluginAlias": "AwairLocal",
 	"pluginType": "accessory",
 	"singular": false,
-	"headerDisplay": "Awair plug-in for [Homebridge](https://github.com/nfarina/homebridge) using the native Awair API. Reference [Installation Instructions](https://github.com/deanlyoung/homebridge-awair#readme) for details on determining 'Developer Token' and 'Device ID'.",
+	"headerDisplay": "Awair plug-in for [Homebridge](https://github.com/nfarina/homebridge) using the native Awair API. Reference [Installation Instructions](https://github.com/deanlyoung/homebridge-awair-local#readme) for details on determining 'Developer Token' and 'Device ID'.",
 	"footerDisplay": "If you have multiple Awair devices, use those IDs to create individual accessories. Be sure to uniquely 'name' each device.",
 	"schema": {
 		"type": "object",

--- a/index.js
+++ b/index.js
@@ -298,7 +298,7 @@ AwairLocal.prototype = {
 		airQualityService
 			.setCharacteristic(Characteristic.AirQuality, "--")
 			.setCharacteristic(Characteristic.VOCDensity, "--")
-			.setCharacteristic(Characteristic.PM2_5Density, "--");
+			.setCharacteristic(Characteristic.PM2_5Density, "--")
 			.setCharacteristic(Characteristic.PM10Density, "--");
 		airQualityService
 			.getCharacteristic(Characteristic.VOCDensity)


### PR DESCRIPTION
Removes the extra semicolon in the airQualityService chain causing the error from issue #9 

The config.schema.json pluginAlias change is to fix an issue caused by adding new accessories with Homebridge Config UI using the wrong accessory attribute value:

```
Error: The requested accessory 'Awair' was not registered by any plugin.
at PluginManager.getPluginForAccessory (/usr/lib/node_modules/homebridge/src/pluginManager.ts:198:15)
```